### PR TITLE
fix for https://wso2.org/jira/browse/BPS-682

### DIFF
--- a/bpel-runtime/src/main/java/org/apache/ode/bpel/engine/BpelRuntimeContextImpl.java
+++ b/bpel-runtime/src/main/java/org/apache/ode/bpel/engine/BpelRuntimeContextImpl.java
@@ -815,7 +815,7 @@ public class BpelRuntimeContextImpl implements BpelRuntimeContext {
         mexDao.setPartnerLink(plinkDAO);
         mexDao.setProcess(_dao.getProcess());
         mexDao.setInstance(_dao);
-        _dao.addMessageExchange(mexDao);
+        //_dao.addMessageExchange(mexDao);// Commented for BPS-682
         mexDao.setPattern((operation.getOutput() != null ? MessageExchangePattern.REQUEST_RESPONSE
                 : MessageExchangePattern.REQUEST_ONLY).toString());
         mexDao.setChannel(channel == null ? null : channel.export());

--- a/dao-jpa/src/main/java/org/apache/ode/dao/jpa/ProcessInstanceDAOImpl.java
+++ b/dao-jpa/src/main/java/org/apache/ode/dao/jpa/ProcessInstanceDAOImpl.java
@@ -174,7 +174,7 @@ public class ProcessInstanceDAOImpl extends OpenJPADAO implements ProcessInstanc
     public ScopeDAO createScope(ScopeDAO parentScope, String name, int scopeModelId) {
         ScopeDAOImpl ret = new ScopeDAOImpl((ScopeDAOImpl)parentScope,name,scopeModelId,this);
         ret.setState(ScopeStateEnum.ACTIVE);
-        _scopes.add(ret);
+        //_scopes.add(ret); // Commented for BPS-682
         _rootScope = (parentScope == null)?ret:_rootScope;
 
         // Must persist the scope to generate a scope ID
@@ -497,7 +497,7 @@ public class ProcessInstanceDAOImpl extends OpenJPADAO implements ProcessInstanc
     }
 
     public void addMessageExchange(MessageExchangeDAO dao) {
-        if (!_messageExchanges.contains(dao)) {
+        if (getEM().find(MessageExchangeDAOImpl.class, dao.getMessageExchangeId()) == null) {
             _messageExchanges.add(dao);
             if (__log.isDebugEnabled()) {
                 __log.debug("MessageExchangeDAO with id:" + dao.getMessageExchangeId() + " is in-cooperated with " +


### PR DESCRIPTION
fix for : https://wso2.org/jira/browse/BPS-682
BPS goes OOM with long running scheduler bpel process.

Main cause is accumulation of Message Exchanges and Scopes for a single process instance. And those get loaded by OpenJPA to the memory due to relationship defined in ProcessInstanceDAOImpl 